### PR TITLE
Extendable socials

### DIFF
--- a/src/components/about/MemberCard.astro
+++ b/src/components/about/MemberCard.astro
@@ -1,10 +1,15 @@
 ---
 import type { MemberInfo } from '@/data/cards/team';
+import SocialSites from '@/data/cards/socials';
 import SocialLink from './SocialLink.astro';
 
 export type Props = MemberInfo
 
 const Props = Astro.props as Props
+
+// Object.entries doesn't provide good key generics
+type EntriesFn = <T>(obj: T) => [keyof T, NonNullable<T[keyof T]>][]
+const entries: EntriesFn = Object.entries
 ---
 
 <div class="member">
@@ -20,17 +25,13 @@ const Props = Astro.props as Props
     </div>
 
     {Props.social!==undefined && <div class="member__social">
-      {Props.social.github !== undefined &&
-      <SocialLink className="member__github" prefix="fab" icon="github"
-        href={`https://github.com/${Props.social.github}`} title="GitHub" />}
-
-      {Props.social.twitter !== undefined &&
-      <SocialLink className="member__twitter" prefix="fab" icon="twitter"
-        href={`https://twitter.com/${Props.social.twitter}`} title="Twitter" />}
-
-      {Props.social.vk !== undefined &&
-      <SocialLink className="member__vk" prefix="fab" icon="vk" href={`https://vk.com/${Props.social.vk}`} title="VK" />
-      }
+      {entries(Props.social).map(([site, username]) => (
+      <SocialLink className={"member__" + site}
+        prefix="fab"
+        icon={SocialSites[site].icon}
+        href={SocialSites[site].url(username)}
+        title={SocialSites[site].title}
+      />))}
     </div>}
 
     <div class="member__description">{Props.description}</div>

--- a/src/data/cards/socials.ts
+++ b/src/data/cards/socials.ts
@@ -1,0 +1,37 @@
+export interface SocialSite {
+  title: string;
+  icon: string;
+  url: (name: string) => string;
+}
+
+const declareSite = (site: SocialSite) => site;
+
+const appendedUrl = (url: string) => (name: string) => `${url}${name}`;
+
+const github = declareSite({
+  title: "GitHub",
+  icon: "github",
+  url: appendedUrl("https://github.com/"),
+});
+
+const twitter = declareSite({
+  title: "Twitter",
+  icon: "twitter",
+  url: appendedUrl("https://twitter.com/"),
+});
+
+const vk = declareSite({
+  title: "VK",
+  icon: "vk",
+  url: appendedUrl("https://vk.com/"),
+});
+
+const SocialSites = {
+  github,
+  twitter,
+  vk,
+};
+
+export type Site = keyof typeof SocialSites;
+
+export default SocialSites

--- a/src/data/cards/team.ts
+++ b/src/data/cards/team.ts
@@ -1,13 +1,11 @@
+import type { Site } from "./socials";
+
 export interface MemberInfo {
   name: string
   description: string
   nickname?: string
   avatar: string
-  social?: {
-    github?: string
-    twitter?: string
-    vk?: string
-  }
+  social?: Partial<Record<Site, string>>
 }
 
 const Team: MemberInfo[] = [


### PR DESCRIPTION
The feature should allow adding more socials  by editing `src/data/cards/socials.ts`. To add mastodon, you could add this.

```ts
// declare the mastodon social site
const mastodon = declareSite({
  title: "Mastodon",
  icon: "mastodon",
  url: appendedUrl("https://mastodon.social/@")
})

// add it to the exported SocialSites
const SocialSites = {
  // ...
  mastodon,
}
```

Now just add it to `src/data/cards/team.ts` file
```ts
const Team: MemberInfo[] = [
  // ...
  {
    // ...
    social: {
      // ...
      mastodon: "username@example.social"
    }
  }
]
```